### PR TITLE
change docs to enable from camelcase to kebabcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enable/disable Markdown Table Formatter.
 
 ```
 {
-  "markdownTableFormatter.enable": true
+  "markdown-table-formatter.enable": true
 }
 ```
 


### PR DESCRIPTION
Noticed in my `settings.json` that `markdownTableFormatter` is an `unknown configuration setting`:

<img width="318" alt="screen shot 2018-11-20 at 4 39 15 pm" src="https://user-images.githubusercontent.com/1024544/48811497-ea272c80-ece2-11e8-886d-876f4b754b36.png">

This PR updates the README.md to reflect the correct key.